### PR TITLE
[BUGFIX] drag and drop javascript call

### DIFF
--- a/Resources/Public/JavaScript/PasteReferenceDragDrop.js
+++ b/Resources/Public/JavaScript/PasteReferenceDragDrop.js
@@ -263,13 +263,18 @@ define(['jquery', 'jquery-ui/droppable', 'TYPO3/CMS/Backend/LayoutModule/DragDro
           });
         });
       } else {
-        parameters['data']['tt_content'][contentElementUid] = {
-          colPos: colPos
+        parameters['cmd']['tt_content'][contentElementUid] = {
+          move: {
+            action: 'paste',
+            target: targetPid,
+            update: {
+              colPos: colPos
+            }
+          }
         };
         if (language > -1) {
-          parameters['data']['tt_content'][contentElementUid]['sys_language_uid'] = language;
+          parameters['cmd']['tt_content'][contentElementUid]['move']['update']['sys_language_uid'] = language;
         }
-        parameters['cmd']['tt_content'][contentElementUid] = {move: targetPid};
         // fire the request, and show a message if it has failed
         require(['TYPO3/CMS/Backend/AjaxDataHandler'], function (DataHandler) {
           DataHandler.process(parameters).done(function (result) {


### PR DESCRIPTION
drag+drop now uses same cmd for copy/move/paste as clipboard

same has changed in core:

s. https://forge.typo3.org/issues/92849
s. https://forge.typo3.org/projects/typo3cms-core/repository/1749/revisions/c1be5540b20421fdfa295a1323b663f3189a41d7

Fixes: #6