### PR TITLE
[BUGFIX] drag and drop javascript call

### DIFF
--- a/Resources/Public/JavaScript/PasteReferenceDragDrop.js
+++ b/Resources/Public/JavaScript/PasteReferenceDragDrop.js
@@ -258,13 +258,18 @@ define(['jquery', 'jquery-ui/droppable', 'TYPO3/CMS/Backend/LayoutModule/DragDro
 					});
 				});
 			} else {
-				parameters['data']['tt_content'][contentElementUid] = {
-					colPos: colPos
-				};
-				if (language > -1) {
-					parameters['data']['tt_content'][contentElementUid]['sys_language_uid'] = language;
+				parameters['cmd']['tt_content'][contentElementUid] = {
+					move: {
+						action: 'paste',
+						target: targetPid,
+						update: {
+							colPos: colPos
+						}
+					}
 				}
-				parameters['cmd']['tt_content'][contentElementUid] = {move: targetPid};
+				if (language > -1) {
+					parameters['cmd']['tt_content'][contentElementUid]['move']['update']['sys_language_uid'] = language;
+				}
 				// fire the request, and show a message if it has failed
 				require(['TYPO3/CMS/Backend/AjaxDataHandler'], function (DataHandler) {
 					DataHandler.process(parameters).done(function (result) {


### PR DESCRIPTION
**This can't be merged into main as it is for a previous version**

This implements the fix done on main (bb7b159606b4625ff923e0f94a772cd3a6650cb2) into version 1.x which is compatible with TYPO3 v10.

This bug occurs when `b13/container` 2.x is installed with TYPO3 v10

Tested on TYPO3 v10.4.32 with `b13/container` versions 1.6 and 2.x

