### PR TITLE
fix: verify global variable TYPO3_REQUEST

### DIFF
--- a/Classes/DataHandler/ProcessCmdmap.php
+++ b/Classes/DataHandler/ProcessCmdmap.php
@@ -55,7 +55,10 @@ class ProcessCmdmap extends AbstractDataHandler
     {
         $this->init($table, $id, $parentObj);
         /** @var ServerRequestInterface $request */
-        $request = $GLOBALS['TYPO3_REQUEST'];
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        if (!($request instanceof ServerRequestInterface)) {
+            return;
+        }
         $queryParams = $request->getQueryParams();
         $reference = isset($queryParams['reference']) ? (int)$queryParams['reference'] : null;
 


### PR DESCRIPTION
Verify that the global Variable exists and is of type ServerRequestInterface before using it.

The command map will exit in case that the request is not available.

Refs: #30