### PR TITLE
fix DataHandler signature

### DIFF
--- a/Classes/DataHandler/ProcessCmdmap.php
+++ b/Classes/DataHandler/ProcessCmdmap.php
@@ -37,20 +37,20 @@ class ProcessCmdmap extends AbstractDataHandler
      * @param string $command The command to be handled by the command map
      * @param string $table The name of the table we are working on
      * @param int $id The id of the record that is going to be copied
-     * @param string $value The value that has been sent with the copy command
+     * @param array|string $value The value that has been sent with the copy command
      * @param bool $commandIsProcessed A switch to tell the parent object, if the record has been copied
      * @param DataHandler|null $parentObj The parent object that triggered this hook
      * @param bool|array $pasteUpdate Values to be updated after the record is pasted
      * @throws DBALException|DBALDriverException
      */
     public function execute_processCmdmap(
-        string      $command,
-        string      $table,
-        int         $id,
-        string      $value,
-        bool        &$commandIsProcessed,
-        DataHandler $parentObj = null,
-        bool|array  $pasteUpdate = false
+        string       $command,
+        string       $table,
+        int          $id,
+        array|string $value,
+        bool         &$commandIsProcessed,
+        DataHandler  $parentObj = null,
+        bool|array   $pasteUpdate = false
     ): void
     {
         $this->init($table, $id, $parentObj);

--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -42,7 +42,7 @@ class DataHandler implements SingletonInterface
      * @param string $command The command to be handled by the command map
      * @param string $table The name of the table we are working on
      * @param int $id The id of the record that is going to be copied
-     * @param string $value The value that has been sent with the copy command
+     * @param array|string $value The value that has been sent with the copy command
      * @param bool $commandIsProcessed A switch to tell the parent object, if the record has been copied
      * @param CoreDataHandler $parentObj The parent object that triggered this hook
      * @param bool|array $pasteUpdate Values to be updated after the record is pasted
@@ -52,7 +52,7 @@ class DataHandler implements SingletonInterface
         string          $command,
         string          $table,
         int             $id,
-        string          $value,
+        array|string    $value,
         bool            &$commandIsProcessed,
         CoreDataHandler &$parentObj,
         bool|array      $pasteUpdate


### PR DESCRIPTION
Our client reported an issue when localizing files.

![bilder](https://github.com/Kephson/paste_reference/assets/7293310/4aab3274-dd48-48d4-9c53-90d9af5e43df)

On the image above you can see an image relation of a translated content element with an image attached.
The grey image below is the image that was assigned in the main language but was removed from the translation.

Using the right button the editor is able to make it available for the localization again. This however throws an error ("undefined" in JS due to PHP Exception in AJAX request), which is directly related to the method signatures of this extension's DataHandler hooks.

`$value` passed to the hook in this case is not a string but an array. For now I added "array" as type to fix the issue.
Not sure what the correct type is, or if we just should leave it open.