### PR TITLE
[BUGFIX] Fix path to language file

### DIFF
--- a/Classes/Hooks/PageLayoutController.php
+++ b/Classes/Hooks/PageLayoutController.php
@@ -68,7 +68,7 @@ class PageLayoutController
      */
     public function drawHeaderHook(): string
     {
-        $this->pageRenderer->addInlineLanguageLabelFile('EXT:paste_reference/Resources/Private/Language/locallang_db.xml', 'tx_paste_reference_js');
+        $this->pageRenderer->addInlineLanguageLabelFile('EXT:paste_reference/Resources/Private/Language/locallang_db.xlf', 'tx_paste_reference_js');
 
         $jsLines = [];
 
@@ -100,7 +100,7 @@ class PageLayoutController
 
     protected function getButtonTemplate(): string
     {
-        $title = $this->helper->getLanguageService()->sL('EXT:paste_reference/Resources/Private/Language/locallang_db.xml:tx_paste_reference_js.copyfrompage');
+        $title = $this->helper->getLanguageService()->sL('EXT:paste_reference/Resources/Private/Language/locallang_db.xlf:tx_paste_reference_js.copyfrompage');
         $icon = $this->iconFactory->getIcon('actions-insert-reference', IconSize::SMALL)->render();
         // the CSS-class "t3js-paste-new" does not exist in system extensions
         return '<button type="button" class="t3js-paste-new btn btn-default btn-sm" title="' . $title . '">' . $icon . '</button>';


### PR DESCRIPTION
This change fixes the path to the language file in 2 places. TYPO3 does not automatically try to lookup for a XML file any more (unsure if TYPO3 ever did). 