### PR TITLE
[BUGFIX] Register user setting in proper TCA format for TYPO3 v14

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,17 +3,32 @@
 defined('TYPO3') || die();
 
 use EHAERER\PasteReference\Hooks\DataHandler;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 (static function () {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass'][] = DataHandler::class;
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = DataHandler::class;
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['moveRecordClass'][] = DataHandler::class;
 
-    $GLOBALS['TYPO3_USER_SETTINGS']['columns']['disableCopyFromPageButton'] = [
-        'type' => 'check',
+    $disableCopyFromPageButtonColumn = [
         'label' => 'LLL:EXT:paste_reference/Resources/Private/Language/locallang.xlf:disableCopyFromPageButton',
     ];
+    if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() >= 14) {
+        // TYPO3 v14 renders the User Settings module through the FormEngine,
+        // which builds a fake "be_users_settings" TCA from these columns and
+        // expects a proper "config" block. Without it, SingleFieldContainer
+        // reads an undefined "config" key and the whole module crashes.
+        $disableCopyFromPageButtonColumn['config'] = [
+            'type' => 'check',
+        ];
+    } else {
+        // TYPO3 v13 and below render the setup form themselves and read the
+        // legacy flat format with the type at the top level.
+        $disableCopyFromPageButtonColumn['type'] = 'check';
+    }
+    $GLOBALS['TYPO3_USER_SETTINGS']['columns']['disableCopyFromPageButton'] = $disableCopyFromPageButtonColumn;
 
     ExtensionManagementUtility::addFieldsToUserSettings(
         '--div--;LLL:EXT:paste_reference/Resources/Private/Language/locallang_db.xlf:pasteReference,disableCopyFromPageButton',


### PR DESCRIPTION
## Problem

Opening the backend **User Settings** (Setup) module on a TYPO3 v14 install with this extension active crashes with a fatal error:

```
PHP Warning: Undefined array key "config" in
vendor/typo3/cms-backend/Classes/Form/Container/SingleFieldContainer.php line 150
at SingleFieldContainer->inlineFieldShouldBeSkipped()
```

This affects **every** backend user, since the `disableCopyFromPageButton` field is shown to all users.

## Root cause

In TYPO3 v14 the User Settings module is rendered through the **FormEngine**. `UserSettingsSchema::getTca()` builds a fake `be_users_settings` TCA by taking every column registered in `$GLOBALS['TYPO3_USER_SETTINGS']['columns']` **verbatim** and expects a proper `config` block.

This extension registers `disableCopyFromPageButton` in the legacy v13 flat format (`type` at the top level, no `config`):

```php
$GLOBALS['TYPO3_USER_SETTINGS']['columns']['disableCopyFromPageButton'] = [
    'type'  => 'check',
    'label' => 'LLL:…',
];
```

So the fake TCA column has no `config`, and `SingleFieldContainer::inlineFieldShouldBeSkipped()` reads an undefined `config` array key. Under the development error handler this escalates to a fatal exception that kills the whole module.

## Fix

Register the field with a nested `config` block on v14+, while keeping the legacy flat format on v13 (whose setup module renders its own form and reads the top-level `type`). The major-version switch uses the same `Typo3Version` pattern already used in `ShortcutPreviewRenderer`, so the extension keeps working across v13.4 and v14.

```php
$disableCopyFromPageButtonColumn = [
    'label' => 'LLL:…',
];
if (GeneralUtility::makeInstance(Typo3Version::class)->getMajorVersion() >= 14) {
    $disableCopyFromPageButtonColumn['config'] = ['type' => 'check'];
} else {
    $disableCopyFromPageButtonColumn['type'] = 'check';
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)